### PR TITLE
Get waypoints working with Leaflet

### DIFF
--- a/vrs-waypoints.html
+++ b/vrs-waypoints.html
@@ -13,7 +13,10 @@
                             clickable: true,
                             draggable: false,
                             editable: false,
-                            icon: waypoints[i].type + ".png",
+                            icon: {
+                                url: waypoints[i].type + ".png",
+                            },
+                            visible: true,
                             tooltip: waypoints[i].name,
                             position: {
                                 lat: waypoints[i].lat,


### PR DESCRIPTION
Unfortunately the Leaflet version of the map plugin only supports the subset of Google icon objects that the main web site uses. It also, unlike the Google version, does not default the "visible" property to true.

This pull request should address both problems so that the markers will show up regardless of whether you're using Google Maps or Leaflet as your map provider.

See forum posting https://forum.virtualradarserver.co.uk/viewtopic.php?f=5&t=1646